### PR TITLE
Add a setup.py file in order to get it buildable/installable directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ tags
 aisparse_test
 speed_test
 tmp
+dist/
+build/
+*.egg-info/
+venv/

--- a/README
+++ b/README
@@ -92,6 +92,11 @@ email signature, capturing the latest ship info from my local receiver.
 
 The runme.py example in the swig directory can also be used. It has an example of parsing a Seaway 1.3 message. In python the struct arrays are not properly understood by the SWIG wrapper, so the helper function that matches the message must be used to first extract the array element before Python can operate on it.
 
+Package can be directly pip installed with recent setuptools:
+
+    python setup.py build_ext --inplace
+    pip install -U .
+
 
 Windows DLL
 -----------

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,37 @@
+from setuptools import setup, Extension
+
+MAJOR_VERSION = 1
+MINOR_VERSION = 0
+PATCH_VERSION = 0
+
+aisparser_module = Extension(
+    name='_aisparser',
+
+    # If some macros are needed
+    define_macros=[
+        ('MAJOR_VERSION', MAJOR_VERSION),
+        ('MINOR_VERSION', MINOR_VERSION),
+        ('PATCH_VERSION', PATCH_VERSION)
+    ],
+
+    sources=[
+        'c/src/access.c',
+        'c/src/imo.c',
+        'c/src/nmea.c',
+        'c/src/seaway.c',
+        'c/src/sixbit.c',
+        'c/src/vdm_parse.c',
+        'python/linux/aisparser.i',
+    ]
+)
+
+
+setup(
+    name = 'python-aisparser',
+    description = 'AIS Parsing library',
+    url = 'https://github.com/bcl/aisparser',
+    version = '{}.{}.{}'.format(MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION),
+    py_modules=['aisparser'],
+    package_dir = {'': 'python/linux'},
+    ext_modules = [aisparser_module],
+)


### PR DESCRIPTION
This allow to directly use setuptools to setup and install this package,
without need to use SWIG directly.
It make it also possible to package as a wheel, by just running:

```
python setup.py build_ext --inplace
python setup.py bdist_wheel
```

a nice next step would be to have this built and deployed on pypi automatically for several platforms